### PR TITLE
Update api_mapping.json

### DIFF
--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -1,4 +1,65 @@
 {
+  "torch.Tensor.select_scatter": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.select_scatter",
+    "min_input_args": 3,
+    "args_list": [
+      "src",
+      "dim",
+      "index"
+    ],
+    "kwargs_change": {
+      "src": "values",
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.slice_scatter": {
+    "Matcher": "TensorSlice_scatterMatcher",
+    "paddle_api": "paddle.Tensor.slice_scatter",
+    "min_input_args": 1,
+    "args_list": [
+      "src",
+      "dim",
+      "start",
+      "end",
+      "step"
+    ],
+    "kwargs_change": {
+      "src": "values",
+      "dim": "axes",  
+      "start": "starts",
+      "end": "ends",
+      "step": "steps"
+    }
+  },
+  "torch.tensor_split": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.tensor_split",
+    "min_input_args": 2,
+    "args_list": [
+      "input",
+      "indices_or_sections",
+      "dim"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "indices_or_sections": "num_or_indices",
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.tensor_split": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.tensor_split",
+    "min_input_args": 1,
+    "args_list": [
+      "indices_or_sections",
+      "dim"
+    ],
+    "kwargs_change": {
+      "indices_or_sections": "num_or_indices",
+      "dim": "axis"
+    }
+  },
   "fairscale.nn.model_parallel.initialize.get_model_parallel_rank": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.distributed.get_rank",


### PR DESCRIPTION
为torch.Tensor.select_scatter、torch.Tensor.slice_scatter、torch.tensor_split、torch.Tensor.tensor_split配置了对应关系

<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->

### PR APIs
<!-- APIs what you've done -->
```bash
torch.Tensor.select_scatter
torch.Tensor.slice_scatter
torch.tensor_split
torch.Tensor.tensor_split
```
